### PR TITLE
wrap output in specs with a debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/doc/
+/lib/
+/bin/
+/.shards/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ puts stm.obtain("something") # This finds, but doesn't splay.
 stm.prune # remove all leaves
 ```
 
+## Testing
+
+To run the specs run `crystal spec`.  To run specs with more debugging output use `LOG_LEVEL=DEBUG crystal spec`.
+
 ## TODO
 
 Experiment with other variations of splay operations, such as lazy semi-splay

--- a/shard.lock
+++ b/shard.lock
@@ -1,0 +1,6 @@
+version: 2.0
+shards:
+  ameba:
+    git: https://github.com/crystal-ameba/ameba.git
+    version: 0.14.3
+

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,3 @@
 require "spec"
+require "log"
 require "../src/splay_tree_map"

--- a/spec/splay_tree_spec.cr
+++ b/spec/splay_tree_spec.cr
@@ -121,7 +121,7 @@ describe SplayTreeMap do
     sum_intermediate_100 = intermediate_heights.reduce(0) { |a, v| a + v }
     sum_regular_100 = regular_heights.reduce(0) { |a, v| a + v }
 
-    puts "\naverage height -- top :: intermediate :: other == #{sum_top_100 / 100} :: #{sum_intermediate_100 / 100} :: #{sum_regular_100 / 100}"
+    Log.debug { "average height -- top :: intermediate :: other == #{sum_top_100 / 100} :: #{sum_intermediate_100 / 100} :: #{sum_regular_100 / 100}" }
     sum_top_100.should be < sum_intermediate_100
     sum_intermediate_100.should be < sum_regular_100
   end


### PR DESCRIPTION
when running specs there is other output in the specs.  I wrapped this in a logger and set it to debug.  This also adds instruction in the readme on how to run the specs.